### PR TITLE
switch pin 12 from adc2 to 36 on adc1

### DIFF
--- a/station/micropython/apps/temperature_tft.py
+++ b/station/micropython/apps/temperature_tft.py
@@ -5,7 +5,7 @@ import st7789, time
 
 import vga1_16x32 as font
 
-pin_temp = ADC(Pin(12))
+pin_temp = ADC(Pin(36))
 pin_temp.atten(ADC.ATTN_11DB)  # full range: 3.3V
 pin_lipo = ADC(Pin(34))
 pin_lipo.atten(ADC.ATTN_11DB)


### PR DESCRIPTION
While using WIFI on the ESP32 the second ADC can't be used. Pin 12 is measured with ADC2 and throws an error when using with activated WIFI. Measuring on Pin 36 (connected to ADC1) works.